### PR TITLE
feat(otel-runner): allow users to disable context propagation via config

### DIFF
--- a/packages/opentelemetry-tasks-runner/README.md
+++ b/packages/opentelemetry-tasks-runner/README.md
@@ -48,6 +48,7 @@ The `@nxpansion/opentelemetry-tasks-runner` supports the following configuration
 - `exporter`: Optional, `otlp` or `console`. The otlp uses gRPC to send traces via the OpenTelemetry Protocol. Defaults to `otlp`
 - `otlpOptions`: Optional. If using the OTLP exporter, you can provide any options as defined by the `@opentelemetry/exporter-otlp-grpc` `OTLPTraceExporter` here.
 - `setupFile`: Optional. [See documentation](#setup-file) on the setup file.
+- `disableContextPropagation`: Optional. If `true`, the traceParent parameter will not be passed to tasks that are ran. [See documentation](#context-propagation).
 
 ### Setup File
 
@@ -70,16 +71,16 @@ It is quite possible that the Nx Command you are running should be instrumented 
 TRACEPARENT=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01 npx nx run app:build --runner=otel
 ```
 
-Additionally, the tasks runner sets the `traceParent` option child tasks that are executed by the runner. Your executor can use this option if like to add instrumentation within the task. This is similar to passing the trace parent as an override option below
+Additionally, the tasks runner sets the `traceParent` option for child tasks that are executed by the runner. Your executor can use this option if you'd like to add instrumentation within the task. This is similar to passing the trace parent as an override option below
 
 ```
-
 npx nx run app:build --runner=otel --traceParent=00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01
 ```
 
-```
+### Disable Context Propagation
+
+Some executors throw an error if additional parameters are passed in that are not defined by the executor's schema. You can disable context propagation using the `disableContextPropagation` option.
 
 ## Running unit tests
 
 Run `nx test opentelemetry-tasks-runner` to execute the tests via [Jest](https://jestjs.io).
-```

--- a/packages/opentelemetry-tasks-runner/src/tasks-runner/opentelemetry-lifecycle.ts
+++ b/packages/opentelemetry-tasks-runner/src/tasks-runner/opentelemetry-lifecycle.ts
@@ -29,7 +29,12 @@ export class OpentelemetryLifecycle implements LifeCycle {
     [taskId: string]: Span;
   } = {};
 
-  constructor(private readonly context?: Context) {
+  constructor(
+    private readonly context?: Context,
+    private readonly options: {
+      disableContextPropagation?: boolean;
+    } = {}
+  ) {
     this.tracer = trace.getTracer('opentelemetry-tasks-runner', '0.1.0');
   }
 
@@ -80,7 +85,9 @@ export class OpentelemetryLifecycle implements LifeCycle {
     this.spans[task.id] = span;
 
     const overrides = task.overrides ?? {};
-    task.overrides = this.setTraceParent(span, overrides);
+    if (!this.options.disableContextPropagation) {
+      task.overrides = this.setTraceParent(span, overrides);
+    }
 
     return span;
   }

--- a/packages/opentelemetry-tasks-runner/src/tasks-runner/types/opentelemetry-tasks-runner-options.type.ts
+++ b/packages/opentelemetry-tasks-runner/src/tasks-runner/types/opentelemetry-tasks-runner-options.type.ts
@@ -37,6 +37,11 @@ export interface OpentelemetryTasksRunnerOptions<T> {
    * If true, nx cache will not be used for executed tasks
    */
   skipNxCache?: boolean;
+
+  /**
+   * If true, the traceParent parameter will not be passed to ran tasks.
+   */
+  disableContextPropagation?: boolean;
   /**
    * The lifecycle provided to this tasks runner that will be combined with the
    * OpenTelemetry lifecycle.

--- a/packages/opentelemetry-tasks-runner/src/tasks-runner/utils/instrument-tasks-runner.ts
+++ b/packages/opentelemetry-tasks-runner/src/tasks-runner/utils/instrument-tasks-runner.ts
@@ -40,7 +40,9 @@ export async function instrumentPromiseTasksRunner(
           ...options.wrappedTasksRunnerOptions,
           ...options,
           lifeCycle: new CompositeLifeCycle([
-            new OpentelemetryLifecycle(api.context.active()),
+            new OpentelemetryLifecycle(api.context.active(), {
+              disableContextPropagation: options.disableContextPropagation,
+            }),
             options.lifeCycle,
           ]),
         },
@@ -96,7 +98,9 @@ export function instrumentObservableTasksRunner(
             ...options.wrappedTasksRunnerOptions,
             ...options,
             lifeCycle: new CompositeLifeCycle([
-              new OpentelemetryLifecycle(activeContext),
+              new OpentelemetryLifecycle(activeContext, {
+                disableContextPropagation: options.disableContextPropagation,
+              }),
               options.lifeCycle,
             ]),
           },


### PR DESCRIPTION
There are executors that will not run if parameters not in its schema are passed to it, such as those in the `@angular` packages.  This pr adds a `disableContextPropagation` option with which you can disable context propagation to avoid such issues.