### PR TITLE
feat(otel-tasks-runner): lazy load exporter libraries and make them optl

### DIFF
--- a/packages/opentelemetry-tasks-runner/.lib.swcrc
+++ b/packages/opentelemetry-tasks-runner/.lib.swcrc
@@ -11,7 +11,7 @@
       "legacyDecorator": true
     },
     "keepClassNames": true,
-    "externalHelpers": true,
+    "externalHelpers": false,
     "loose": true
   },
   "module": {

--- a/packages/opentelemetry-tasks-runner/README.md
+++ b/packages/opentelemetry-tasks-runner/README.md
@@ -45,8 +45,8 @@ The `@nxpansion/opentelemetry-tasks-runner` supports the following configuration
 
 - `wrappedTasksRunner`: The tasks runner to instrument. At some level the tasks runner must use the default nx tasks runner to execute tasks. The `@nrwl/workspace/tasks-runners/default` and `@nrwl/nx-cloud` tasks runners both are supported.
 - `wrappedTasksRunnerOptions`: These options will be passed to the wrapped tasks runner.
-- `exporter`: Optional, `otlp-grpc`, `otlp-http` or `console`. The otlp uses gRPC to send traces via the OpenTelemetry Protocol. Defaults to `otlp-grpc`
-- `otlpOptions`: Optional. If using the OTLP exporter, you can provide any options as defined by the `@opentelemetry/exporter-trace-otlp-grpc` `OTLPTraceExporter` here.
+- `exporter`: Optional, `otlp-grpc`, `otlp-http` or `console`. Defaults to `console`.
+- `otlpOptions`: Optional. If using the OTLP exporter, you can provide any options as defined by the `@opentelemetry/exporter-trace-otlp-grpc` or `@opentelemetry/exporter-trace-otlp-http`.
 - `setupFile`: Optional. [See documentation](#setup-file) on the setup file.
 - `disableContextPropagation`: Optional. If `true`, the traceParent parameter will not be passed to tasks that are ran. [See documentation](#context-propagation).
 - `isLegacyTasksRunner`: Option. Some older tasks runners return an observable instead of a Promise. If the tasks runner you are wrapping returns an observable, set this option to `true`.

--- a/packages/opentelemetry-tasks-runner/package.json
+++ b/packages/opentelemetry-tasks-runner/package.json
@@ -13,5 +13,13 @@
   "dependencies": {
     "@swc/helpers": "~0.3.3"
   },
-  "devDependencies": {}
+  "devDependencies": {},
+  "peerDependenciesMeta": {
+    "@opentelemetry/exporter-trace-otlp-grpc": {
+      "optional": true
+    },
+    "@opentelemetry/exporter-trace-otlp-http": {
+      "optional": true
+    }
+  }
 }

--- a/packages/opentelemetry-tasks-runner/package.json
+++ b/packages/opentelemetry-tasks-runner/package.json
@@ -10,9 +10,6 @@
     "@nrwl/devkit": "^13.10.0",
     "nx": "^13.10.0"
   },
-  "dependencies": {
-    "@swc/helpers": "~0.3.3"
-  },
   "devDependencies": {},
   "peerDependenciesMeta": {
     "@opentelemetry/exporter-trace-otlp-grpc": {

--- a/packages/opentelemetry-tasks-runner/src/tasks-runner/types/opentelemetry-tasks-runner-options.type.ts
+++ b/packages/opentelemetry-tasks-runner/src/tasks-runner/types/opentelemetry-tasks-runner-options.type.ts
@@ -1,4 +1,3 @@
-import { OTLPExporterConfigNode } from '@opentelemetry/exporter-trace-otlp-grpc/build/src/types';
 import { LifeCycle } from 'nx/src/tasks-runner/life-cycle';
 
 export interface OpentelemetryTasksRunnerOptions<T> {
@@ -24,10 +23,10 @@ export interface OpentelemetryTasksRunnerOptions<T> {
    */
   exporter?: 'otlp' | 'otlp-grpc' | 'otlp-http' | 'console';
   /**
-   * If using the OTLP exporter, you can provide an options to be passed into
+   * If using an OTLP exporter, you can provide any options to be passed into
    * the exporter here.
    */
-  otlpOptions?: OTLPExporterConfigNode;
+  otlpOptions?: any;
   /**
    * Allows a custom NodeSdk to be set up, allowing for custom processors
    * and exporters.

--- a/packages/opentelemetry-tasks-runner/src/tasks-runner/utils/get-default-otel-node-sdk-configuration.ts
+++ b/packages/opentelemetry-tasks-runner/src/tasks-runner/utils/get-default-otel-node-sdk-configuration.ts
@@ -1,5 +1,3 @@
-import { OTLPTraceExporter as OTLPGRPCTraceExporter } from '@opentelemetry/exporter-trace-otlp-grpc';
-import { OTLPTraceExporter as OTLPHTTPTraceExporter } from '@opentelemetry/exporter-trace-otlp-http';
 import { Resource } from '@opentelemetry/resources';
 import { NodeSDKConfiguration } from '@opentelemetry/sdk-node';
 import { SemanticResourceAttributes } from '@opentelemetry/semantic-conventions';
@@ -14,12 +12,26 @@ export function getDefaultOtelNodeSdkConfiguration(
   options: OpentelemetryTasksRunnerOptions<any>
 ): Partial<NodeSDKConfiguration> {
   let spanExporter: SpanExporter;
-  if (options.exporter === 'console') {
-    spanExporter = new ConsoleSpanExporter();
-  } else if (options.exporter === 'otlp-http') {
-    spanExporter = new OTLPHTTPTraceExporter(options.otlpOptions);
+  if (options.exporter === 'otlp-http') {
+    const {
+      OTLPTraceExporter,
+    } = require('@opentelemetry/exporter-trace-otlp-http');
+    spanExporter = new OTLPTraceExporter(options.otlpOptions);
+  } else if (options.exporter === 'otlp-grpc') {
+    const {
+      OTLPTraceExporter,
+    } = require('@opentelemetry/exporter-trace-otlp-grpc');
+    spanExporter = new OTLPTraceExporter(options.otlpOptions);
+  } else if (options.exporter === 'otlp') {
+    console.warn(
+      'The otlp option is deprecated. This will be removed in future versions. Use otlp-grpc instead'
+    );
+    const {
+      OTLPTraceExporter,
+    } = require('@opentelemetry/exporter-trace-otlp-grpc');
+    spanExporter = new OTLPTraceExporter(options.otlpOptions);
   } else {
-    spanExporter = new OTLPGRPCTraceExporter(options.otlpOptions);
+    spanExporter = new ConsoleSpanExporter();
   }
   const spanProcessor = new BatchSpanProcessor(spanExporter);
   return {


### PR DESCRIPTION
This PR addresses Issue #5.  It makes the OTLP HTTP and gRPC exporters optional peer dependencies.  The dependencies are only required if you configure the tasks runner to use those specific exporters.

## Breaking Changes
This PR changes the default exporter from `otlp-grpc` to `console`.  This way if you do not specify a specific exporter, no additional exporter packages will be required to be installed.