### PR TITLE
fix(otel-tasks-runner): fix legacy tasks runner observable handling

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -14,12 +14,7 @@
     "default": {
       "runner": "nx/tasks-runners/default",
       "options": {
-        "cacheableOperations": [
-          "build",
-          "lint",
-          "test",
-          "e2e"
-        ],
+        "cacheableOperations": ["build", "lint", "test", "e2e"],
         "parallel": 1
       }
     },
@@ -28,12 +23,7 @@
       "options": {
         "wrappedTasksRunner": "@nrwl/workspace/tasks-runners/default",
         "wrappedTasksRunnerOptions": {
-          "cacheableOperations": [
-            "build",
-            "lint",
-            "test",
-            "e2e"
-          ]
+          "cacheableOperations": ["build", "lint", "test", "e2e"]
         },
         "setupFile": "./packages/opentelemetry-tasks-runner/src/test/setup.js"
       }
@@ -43,15 +33,11 @@
       "options": {
         "wrappedTasksRunner": "@nrwl/nx-cloud",
         "wrappedTasksRunnerOptions": {
-          "cacheableOperations": [
-            "build",
-            "lint",
-            "test",
-            "e2e"
-          ],
+          "cacheableOperations": ["build", "lint", "test", "e2e"],
           "accessToken": "MWJjZTdkMjAtOTgwNy00YjE4LTg1OGUtZTgxNzA2ZDVhZTc0fHJlYWQtd3JpdGU="
         },
-        "exporter": "console"
+        "exporter": "console",
+        "isLegacyTasksRunner": true
       }
     }
   },

--- a/packages/opentelemetry-tasks-runner/README.md
+++ b/packages/opentelemetry-tasks-runner/README.md
@@ -49,6 +49,7 @@ The `@nxpansion/opentelemetry-tasks-runner` supports the following configuration
 - `otlpOptions`: Optional. If using the OTLP exporter, you can provide any options as defined by the `@opentelemetry/exporter-trace-otlp-grpc` `OTLPTraceExporter` here.
 - `setupFile`: Optional. [See documentation](#setup-file) on the setup file.
 - `disableContextPropagation`: Optional. If `true`, the traceParent parameter will not be passed to tasks that are ran. [See documentation](#context-propagation).
+- `isLegacyTasksRunner`: Option. Some older tasks runners return an observable instead of a Promise. If the tasks runner you are wrapping returns an observable, set this option to `true`.
 
 ### Setup File
 


### PR DESCRIPTION
In wrapping legacy tasks runners, we needed to prevent the wrapped observable from emitting its response until we shut down the otel sdk.  This PR uses a more appropriate operator (`delayWhen`) to delay the emission without changing the value.

Additionally, it documents the `isLegacyTasksRunner` option.